### PR TITLE
Disallow rolling back the migration

### DIFF
--- a/database/migrations/2019_11_21_000000_change_action_event_ids_to_strings.php
+++ b/database/migrations/2019_11_21_000000_change_action_event_ids_to_strings.php
@@ -28,11 +28,6 @@ class ChangeActionEventIdsToStrings extends Migration
      */
     public function down()
     {
-        Schema::table('action_events', function (Blueprint $table) {
-            $table->integer('actionable_id')->unsigned()->change();
-            $table->integer('model_id')->unsigned()->change();
-            $table->integer('target_id')->unsigned()->change();
-            $table->integer('user_id')->unsigned()->change();
-        });
+        // this migration cannot be rolled back without losing data
     }
 }


### PR DESCRIPTION
As reported in https://github.com/madewithlove/laravel-nova-uuid-support/issues/5
this cannot be rolled back. Rolling back this migration would make us lose all data.